### PR TITLE
fix: do not allow extend expiration for expired token

### DIFF
--- a/sources/name_service.move
+++ b/sources/name_service.move
@@ -474,6 +474,10 @@ module usernames::usernames {
 
         let (_height, timestamp) = block::get_block_info();
         let expiration_date = metadata::get_expiration_date(token);
+
+        // Not allow extend for expired one. Reregister indstead. 
+        assert!(expiration_date + module_store.config.grace_period >= timestamp, error::invalid_state(ETOKEN_EXPIRED));
+
         let new_expiration_date = if (expiration_date > timestamp) {
             expiration_date + duration
         } else {


### PR DESCRIPTION
To prevent front run (insert tx that register before other user extend expiration for expired domain), disable extending for expired domain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Introduced stricter validation for domain renewals to prevent extending expired domains. Users will now need to re-register domains whose registration has lapsed, ensuring enhanced error handling and improved domain management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->