### PR TITLE
fix: use constant price and will update to slinky

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -6,10 +6,6 @@ version = "0.0.1"
 std = "0x1"
 initia_std = "0x1"
 usernames = "0x42cd8467b1c86e59bf319e5664a09b6b5840bb3fac64f5ce690b5041c530565a"
-pair = "_"
-
-[dev-addresses]
-pair = "0x892d79399f244a7fe7273c27ece2b5c36024131565fcd331fc3dc9c480add001"
 
 [dependencies]
 InitiaStdlib = { git = "https://github.com/initia-labs/move-natives.git", subdir = "initia_stdlib", rev = "main" }


### PR DESCRIPTION
Use init price as 1.0 at first and will update this to slinky oracle price

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores: Simplified configuration by removing obsolete address entries.
- Refactor: Updated the user naming functionality by deprecating legacy components and consolidating similar structures.
- Tests: Streamlined the testing setup by merging duplicate elements and adjusting initialization parameters for a cleaner process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->