### PR TITLE
fix: add expired check to update_records

### DIFF
--- a/sources/name_service.move
+++ b/sources/name_service.move
@@ -546,12 +546,19 @@ module usernames::usernames {
 
         let module_store = borrow_global_mut<ModuleStore>(@usernames);
         domain_name = to_lower_case(&domain_name);
+
         let token = *table::borrow(&module_store.name_to_token, domain_name);
         let token_object = object::address_to_object<Metadata>(token);
+
+        let (_height, timestamp) = block::get_block_info();
+        assert!(
+            metadata::get_expiration_date(token) > timestamp,
+            error::permission_denied(ETOKEN_EXPIRED),
+        )
+        ;
         assert!(object::is_owner(token_object, addr), error::permission_denied(ENOT_OWNER));
 
         metadata::delete_records(token, record_keys);
-
         event::emit(
             DeleteRecordsEvent {
                 addr,

--- a/sources/name_service.move
+++ b/sources/name_service.move
@@ -514,12 +514,19 @@ module usernames::usernames {
 
         let module_store = borrow_global_mut<ModuleStore>(@usernames);
         domain_name = to_lower_case(&domain_name);
+
         let token = *table::borrow(&module_store.name_to_token, domain_name);
         let token_object = object::address_to_object<Metadata>(token);
+
+        let (_height, timestamp) = block::get_block_info();
+        assert!(
+            metadata::get_expiration_date(token) > timestamp,
+            error::permission_denied(ETOKEN_EXPIRED),
+        );
+
         assert!(object::is_owner(token_object, addr), error::permission_denied(ENOT_OWNER));
 
         metadata::update_records(token, record_keys, record_values);
-
         event::emit(
             UpdateRecordsEvent {
                 addr,


### PR DESCRIPTION
Add expiration check to update_records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the record update and deletion processes with token expiration validation. Actions using expired tokens are now reliably blocked, ensuring users receive clear error messages and improved data security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->