### PR TITLE
fix: remove redundant validation for upper case character

### DIFF
--- a/sources/name_service.move
+++ b/sources/name_service.move
@@ -384,7 +384,7 @@ module usernames::usernames {
 
         let cost_amount = get_cost_amount(domain_name, duration);
         let module_store = borrow_global_mut<ModuleStore>(@usernames);
-        let cost = primary_fungible_store::withdraw(account, get_init_metadata(), (cost_amount as u64));
+        let cost = primary_fungible_store::withdraw(account, get_init_metadata(), cost_amount);
         primary_fungible_store::deposit(module_store.pool, cost);
 
         event::emit(
@@ -567,7 +567,6 @@ module usernames::usernames {
             assert!(
                 char == 45 || // -
                 (char >= 48 && char <= 57) || // 0 ~ 9
-                (char >= 65 && char <= 90) || // A ~ Z
                 (char >= 97 && char <= 122), // a ~ z
                 error::invalid_argument(EINVALID_CHARACTER),
             );


### PR DESCRIPTION
- remove redundant validation for upper case character. It never reach because of the `to_lower_case`
- remove unnecessary type cast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified internal cost processing for domain registration and renewal transactions, enhancing transaction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->